### PR TITLE
Add ability to get & see all existing lines for every player

### DIFF
--- a/Attt_LocalEngine_Kotlin/build.gradle.kts
+++ b/Attt_LocalEngine_Kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "org.igor_shaula"
-version = "0.7.6"
+version = "0.8.0"
 
 repositories {
     mavenCentral()

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/attt/Game.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/attt/Game.kt
@@ -37,6 +37,8 @@ interface Game {
 
     fun printCurrentFieldIn2d()
 
+    fun printExistingLinesFor(player: Player)
+
     companion object {
         /**
          * create AtttGame instance & provide the UI with a new game field, adjustability happens here - in the parameters

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/attt/Game.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/attt/Game.kt
@@ -39,6 +39,10 @@ interface Game {
 
     fun printExistingLinesFor(player: Player)
 
+    fun printExistingLinesForLeadingPlayer()
+
+    fun printExistingLinesForTheWinner()
+
     companion object {
         /**
          * create AtttGame instance & provide the UI with a new game field, adjustability happens here - in the parameters

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameField.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameField.kt
@@ -35,14 +35,16 @@ internal class GameField(
      * returns beautiful & simple String representation of the current state of game field
      */
     internal fun prepareForPrinting3dIn2d(
-        chosenAlgorithm: OneMoveProcessing = NearestAreaScanWithXY(this), zAxisSize: Int = 1 // for tests
+        chosenAlgorithm: OneMoveProcessing = NearestAreaScanWithXY(this), // this default value works for tests
+        zAxisSize: Int = 1, // this default value works for tests
+        givenMap: MutableMap<Coordinates, Player> = theMap
     ): String {
         val sb = StringBuilder(sideLength * (zAxisSize + 2) * (sideLength + 1)) // for: y * (z+2) * (x+1)
         for (y in 0 until sideLength) {
             sb.append(SYMBOL_FOR_NEW_LINE)
             for (z in 0 until zAxisSize) { // will work only once for 2D
                 for (x in 0 until sideLength) {
-                    sb.append(theMap[chosenAlgorithm.getCoordinatesFor(x, y, z)]?.symbol ?: SYMBOL_FOR_ABSENT_MARK)
+                    sb.append(givenMap[chosenAlgorithm.getCoordinatesFor(x, y, z)]?.symbol ?: SYMBOL_FOR_ABSENT_MARK)
                         .append(SYMBOL_FOR_DIVIDER) // between adjacent marks inside one field slice
                 }
                 repeat(2) { sb.append(SYMBOL_FOR_DIVIDER) } // between the fields for each slice of every Z axis value

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameField.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameField.kt
@@ -2,6 +2,7 @@ package gameLogic
 
 import attt.Player
 import constants.*
+import geometry.Line
 import geometry.abstractions.Coordinates
 import geometry.abstractions.OneMoveProcessing
 import geometry.conceptXY.NearestAreaScanWithXY
@@ -43,6 +44,34 @@ internal class GameField(
                 for (x in 0 until sideLength) {
                     sb.append(theMap[chosenAlgorithm.getCoordinatesFor(x, y, z)]?.symbol ?: SYMBOL_FOR_ABSENT_MARK)
                         .append(SYMBOL_FOR_DIVIDER) // between adjacent marks inside one field slice
+                }
+                repeat(2) { sb.append(SYMBOL_FOR_DIVIDER) } // between the fields for each slice of every Z axis value
+            }
+        }
+        return sb.toString()
+    }
+
+    fun prepareForPrinting3dIn2d(
+        chosenAlgorithm: OneMoveProcessing,
+        zAxisSize: Int,
+        player: Player,
+        allExistingLinesForThisPlayer: MutableSet<Line?>?
+    ): String {
+        val onePlayerMap: MutableMap<Coordinates, Player> = mutableMapOf() // initially empty to save memory
+        allExistingLinesForThisPlayer?.forEach { line ->
+            line?.marks?.forEach { mark ->
+                onePlayerMap[mark] = player
+            }
+        }
+
+        val sb = StringBuilder(sideLength * (zAxisSize + 2) * (sideLength + 1)) // for: y * (z+2) * (x+1)
+        for (y in 0 until sideLength) {
+            sb.append(SYMBOL_FOR_NEW_LINE)
+            for (z in 0 until zAxisSize) { // will work only once for 2D
+                for (x in 0 until sideLength) {
+                    sb.append(
+                        onePlayerMap[chosenAlgorithm.getCoordinatesFor(x, y, z)]?.symbol ?: SYMBOL_FOR_ABSENT_MARK
+                    ).append(SYMBOL_FOR_DIVIDER) // between adjacent marks inside one field slice
                 }
                 repeat(2) { sb.append(SYMBOL_FOR_DIVIDER) } // between the fields for each slice of every Z axis value
             }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameField.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameField.kt
@@ -53,11 +53,11 @@ internal class GameField(
         return sb.toString()
     }
 
-    fun prepareForPrinting3dIn2d(
+    internal fun prepareForPrintingPlayerLines(
+        player: Player,
+        allExistingLinesForThisPlayer: MutableSet<Line?>?,
         chosenAlgorithm: OneMoveProcessing,
         zAxisSize: Int,
-        player: Player,
-        allExistingLinesForThisPlayer: MutableSet<Line?>?
     ): String {
         val onePlayerMap: MutableMap<Coordinates, Player> = mutableMapOf() // initially empty to save memory
         allExistingLinesForThisPlayer?.forEach { line ->
@@ -65,20 +65,7 @@ internal class GameField(
                 onePlayerMap[mark] = player
             }
         }
-
-        val sb = StringBuilder(sideLength * (zAxisSize + 2) * (sideLength + 1)) // for: y * (z+2) * (x+1)
-        for (y in 0 until sideLength) {
-            sb.append(SYMBOL_FOR_NEW_LINE)
-            for (z in 0 until zAxisSize) { // will work only once for 2D
-                for (x in 0 until sideLength) {
-                    sb.append(
-                        onePlayerMap[chosenAlgorithm.getCoordinatesFor(x, y, z)]?.symbol ?: SYMBOL_FOR_ABSENT_MARK
-                    ).append(SYMBOL_FOR_DIVIDER) // between adjacent marks inside one field slice
-                }
-                repeat(2) { sb.append(SYMBOL_FOR_DIVIDER) } // between the fields for each slice of every Z axis value
-            }
-        }
-        return sb.toString()
+        return prepareForPrinting3dIn2d(chosenAlgorithm, zAxisSize, onePlayerMap)
     }
 
     /**

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameProgress.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameProgress.kt
@@ -12,7 +12,7 @@ import utilities.Log
 /**
  * a single point of check if anybody wins, also container for all limitations & settings of game mechanics.
  */
-internal class GameRules(
+internal class GameProgress(
     private var winningLength: Int
     // potentially here we can later add more criteria to detect if the game is won by any of players
 ) {

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameRules.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameRules.kt
@@ -4,6 +4,7 @@ import attt.Player
 import constants.MAX_WINNING_LINE_LENGTH
 import constants.MIN_WINNING_LINE_LENGTH
 import geometry.Line
+import geometry.abstractions.Coordinates
 import geometry.getMaxLength
 import players.PlayerModel
 import utilities.Log
@@ -60,5 +61,10 @@ internal class GameRules(
         }
         setOfThisPlayerLines.add(line)
         allPlayersLines[player] = setOfThisPlayerLines
+    }
+
+    internal fun addToRecentLine(player: Player, coordinates: Coordinates) {
+        // as LinkedHashSet is the default implementation of Set in Kotlin - we have the order of insertions preserved
+        allPlayersLines[player]?.last()?.add(coordinates)
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameRules.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameRules.kt
@@ -5,7 +5,6 @@ import constants.MAX_WINNING_LINE_LENGTH
 import constants.MIN_WINNING_LINE_LENGTH
 import geometry.Line
 import geometry.getMaxLength
-import players.PlayerProvider
 import players.PlayerModel
 import utilities.Log
 
@@ -20,7 +19,7 @@ internal class GameRules(
     private val maxLines: MutableMap<Player, Int> = mutableMapOf()
 
     // contains all detected lines for every player - should not be looped/read during every move
-    private val allPlayersLines: MutableMap<Player, MutableSet<Line?>> = mutableMapOf()
+    internal val allPlayersLines: MutableMap<Player, MutableSet<Line?>> = mutableMapOf()
 
     private var theWinner: Player = PlayerModel.None
 
@@ -55,7 +54,11 @@ internal class GameRules(
     }
 
     internal fun saveNewLine(player: Player, line: Line) {
-        allPlayersLines[player]?.add(line)
-        Log.pl("saveNewLine: saved new line: $line for player: ${player.name}")
+        var setOfThisPlayerLines = allPlayersLines[player]
+        if (setOfThisPlayerLines == null) { // here we do not know currently existing number of players
+            setOfThisPlayerLines = mutableSetOf() // because initially a set for every player does not exist
+        }
+        setOfThisPlayerLines.add(line)
+        allPlayersLines[player] = setOfThisPlayerLines
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -23,7 +23,7 @@ internal class GameSession(
     private val useNewDimensionsBasedLogic = true
 
     internal var gameField: GameField = GameField(desiredFieldSize)
-    private var gameRules: GameRules = GameRules(desiredMaxLineLength)
+    internal var gameRules: GameRules = GameRules(desiredMaxLineLength)
 
     // the only place for switching between kinds of algorithms for every move processing
     internal val chosenAlgorithm: OneMoveProcessing =
@@ -95,5 +95,15 @@ internal class GameSession(
         val zAxisSize = if (is3D) gameField.sideLength else 1
         // not using Log.pl here as this action is intentional & has not be able to switch off
         println(gameField.prepareForPrinting3dIn2d(chosenAlgorithm, zAxisSize))
+    }
+
+    fun printExistingLinesFor(player: Player) {
+        println("printExistingLinesFor")
+        val allExistingLinesForThisPlayer = gameRules.allPlayersLines[player]
+        println(allExistingLinesForThisPlayer)
+        // reasonable sideLength here is 1 -> minIndex = 0 -> only one layer in Z dimension will exist
+        val zAxisSize = if (is3D) gameField.sideLength else 1
+        // not using Log.pl here as this action is intentional & has not be able to switch off
+        println(gameField.prepareForPrinting3dIn2d(chosenAlgorithm, zAxisSize, player, allExistingLinesForThisPlayer))
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -97,7 +97,7 @@ internal class GameSession(
         println(gameField.prepareForPrinting3dIn2d(chosenAlgorithm, zAxisSize))
     }
 
-    fun printExistingLinesFor(player: Player) {
+    override fun printExistingLinesFor(player: Player) {
         val allExistingLinesForThisPlayer = gameRules.allPlayersLines[player]
         // reasonable sideLength here is 1 -> minIndex = 0 -> only one layer in Z dimension will exist
         val zAxisSize = if (is3D) gameField.sideLength else 1

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -54,7 +54,9 @@ internal class GameSession(
      */
     internal fun makeMove(where: Coordinates, what: Player = PlayerProvider.activePlayer): Player =
         if (gameField.placeNewMark(where, what)) {
-            chosenAlgorithm.getMaxLengthAchievedForThisMove(where)?.let {
+            chosenAlgorithm.getMaxLengthAchievedForThisMove(where) { player, line ->
+                gameRules.saveNewLine(player, line)
+            }?.let {
                 Log.pl("makeMove: maxLength for this move of player ${what.name} is: $it")
                 // this cast is secure as PlayerModel is direct inheritor to AtttPlayer
                 (what as PlayerModel).tryToSetMaxLineLength(it)

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -54,9 +54,11 @@ internal class GameSession(
      */
     internal fun makeMove(where: Coordinates, what: Player = PlayerProvider.activePlayer): Player =
         if (gameField.placeNewMark(where, what)) {
-            chosenAlgorithm.getMaxLengthAchievedForThisMove(where) { player, line ->
-                gameRules.saveNewLine(player, line)
-            }?.let {
+            chosenAlgorithm.getMaxLengthAchievedForThisMove(
+                where,
+                saveNewLine = { player, line -> gameRules.saveNewLine(player, line) },
+                addNewMark = { player, coordinates -> gameRules.addToRecentLine(player, coordinates) }
+            )?.let {
                 Log.pl("makeMove: maxLength for this move of player ${what.name} is: $it")
                 // this cast is secure as PlayerModel is direct inheritor to AtttPlayer
                 (what as PlayerModel).tryToSetMaxLineLength(it)

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -23,7 +23,7 @@ internal class GameSession(
     private val useNewDimensionsBasedLogic = true
 
     internal var gameField: GameField = GameField(desiredFieldSize)
-    internal var gameRules: GameRules = GameRules(desiredMaxLineLength)
+    internal var gameProgress: GameProgress = GameProgress(desiredMaxLineLength)
 
     // the only place for switching between kinds of algorithms for every move processing
     internal val chosenAlgorithm: OneMoveProcessing =
@@ -56,15 +56,15 @@ internal class GameSession(
         if (gameField.placeNewMark(where, what)) {
             chosenAlgorithm.getMaxLengthAchievedForThisMove(
                 where,
-                saveNewLine = { player, line -> gameRules.saveNewLine(player, line) },
-                addNewMark = { player, coordinates -> gameRules.addToRecentLine(player, coordinates) }
+                saveNewLine = { player, line -> gameProgress.saveNewLine(player, line) },
+                addNewMark = { player, coordinates -> gameProgress.addToRecentLine(player, coordinates) }
             )?.let {
                 Log.pl("makeMove: maxLength for this move of player ${what.name} is: $it")
                 // this cast is secure as PlayerModel is direct inheritor to AtttPlayer
                 (what as PlayerModel).tryToSetMaxLineLength(it)
-                gameRules.updatePlayerScore(what, it)
+                gameProgress.updatePlayerScore(what, it)
             }
-            PlayerProvider.prepareNextPlayer(gameRules.isGameWon())
+            PlayerProvider.prepareNextPlayer(gameProgress.isGameWon())
             PlayerProvider.activePlayer
         } else {
             what // current player's mark was not successfully placed - prepared player stays the same
@@ -73,17 +73,17 @@ internal class GameSession(
     /**
      * a client might want to know the currently leading player at any time during the game
      */
-    override fun getLeader(): Player = gameRules.getLeadingPlayer()
+    override fun getLeader(): Player = gameProgress.getLeadingPlayer()
 
     /**
      * there can be only one winner - Player.None is returned until the winner not yet detected
      */
-    override fun getWinner(): Player = gameRules.getWinner()
+    override fun getWinner(): Player = gameProgress.getWinner()
 
     /**
      * after the winner is detected there is no way to modify the game field, so the game state is preserved
      */
-    override fun isGameWon() = gameRules.isGameWon()
+    override fun isGameWon() = gameProgress.isGameWon()
 
     override fun isGameFinished(): Boolean = isGameWon() || gameField.isCompletelyOccupied(is3D)
 
@@ -98,7 +98,7 @@ internal class GameSession(
     }
 
     override fun printExistingLinesFor(player: Player) {
-        val allExistingLinesForThisPlayer = gameRules.allPlayersLines[player]
+        val allExistingLinesForThisPlayer = gameProgress.allPlayersLines[player]
         // reasonable sideLength here is 1 -> minIndex = 0 -> only one layer in Z dimension will exist
         val zAxisSize = if (is3D) gameField.sideLength else 1
         // not using Log.pl here as this action is intentional & has not be able to switch off
@@ -110,10 +110,10 @@ internal class GameSession(
     }
 
     override fun printExistingLinesForLeadingPlayer() {
-        printExistingLinesFor(gameRules.getLeadingPlayer())
+        printExistingLinesFor(gameProgress.getLeadingPlayer())
     }
 
     override fun printExistingLinesForTheWinner() {
-        printExistingLinesFor(gameRules.getWinner())
+        printExistingLinesFor(gameProgress.getWinner())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -98,9 +98,7 @@ internal class GameSession(
     }
 
     fun printExistingLinesFor(player: Player) {
-        println("printExistingLinesFor")
         val allExistingLinesForThisPlayer = gameRules.allPlayersLines[player]
-        println(allExistingLinesForThisPlayer)
         // reasonable sideLength here is 1 -> minIndex = 0 -> only one layer in Z dimension will exist
         val zAxisSize = if (is3D) gameField.sideLength else 1
         // not using Log.pl here as this action is intentional & has not be able to switch off

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -108,4 +108,12 @@ internal class GameSession(
             )
         )
     }
+
+    override fun printExistingLinesForLeadingPlayer() {
+        printExistingLinesFor(gameRules.getLeadingPlayer())
+    }
+
+    override fun printExistingLinesForTheWinner() {
+        printExistingLinesFor(gameRules.getWinner())
+    }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/gameLogic/GameSession.kt
@@ -104,6 +104,10 @@ internal class GameSession(
         // reasonable sideLength here is 1 -> minIndex = 0 -> only one layer in Z dimension will exist
         val zAxisSize = if (is3D) gameField.sideLength else 1
         // not using Log.pl here as this action is intentional & has not be able to switch off
-        println(gameField.prepareForPrinting3dIn2d(chosenAlgorithm, zAxisSize, player, allExistingLinesForThisPlayer))
+        println(
+            gameField.prepareForPrintingPlayerLines(
+                player, allExistingLinesForThisPlayer, chosenAlgorithm, zAxisSize
+            )
+        )
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/Line.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/Line.kt
@@ -1,6 +1,5 @@
 package geometry
 
-import constants.MAX_WINNING_LINE_LENGTH
 import geometry.abstractions.Coordinates
 
 /**
@@ -11,36 +10,42 @@ import geometry.abstractions.Coordinates
  * processing/detecting of the line direction is not a job of the line.
  * all existing lines are meant to be proven/correct/checked to be straight & aligned in a direction.
  */
-internal data class Line(val startingMark: Coordinates, val adjacentMark: Coordinates) {
+internal class Line(startingMark: Coordinates, adjacentMark: Coordinates) {
 
-    // decided to initially allocate maximum of memory to avoid possible re-allocations
-    val marks: ArrayDeque<Coordinates> = ArrayDeque(initialCapacity = MAX_WINNING_LINE_LENGTH)
+    /**
+     * why a Set? -> because each coordinate is unique, and also we need unordered set
+     * - to avoid keeping track of a starting point and its repositioning in case of adding a new mark before it.
+     * also I decided to avoid using LineDirection concept here - for simplicity.
+     * all control of line correctness is done at the level of line detection inside existing logic chains.
+     */
+    val marks: MutableSet<Coordinates> = mutableSetOf()
 
     init {
-        marks.addFirst(startingMark)
-        marks.addLast(adjacentMark)
+        marks.add(startingMark)
+        marks.add(adjacentMark)
     }
 
-    internal fun addToHead(newMark: Coordinates) {
-        marks.addFirst(newMark)
+    internal fun add(newMark: Coordinates) {
+        marks.add(newMark)
     }
 
-    internal fun addToTail(newMark: Coordinates) {
-        marks.addLast(newMark)
-    }
+    /*
+        // it is decided to treat two lines with similar marks but opposite direction as one (the same) line
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return if (other == null || other !is Line) false
+            else this.startingMark == other.adjacentMark && this.adjacentMark == other.startingMark
+        }
 
-    // it is decided to treat two lines with similar marks but opposite direction as one (the same) line
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        return if (other == null || other !is Line) false
-        else this.startingMark == other.adjacentMark && this.adjacentMark == other.startingMark
-    }
-
-    // if we override equals -> we have to override hashCode as well to prevent from breaking their contract
-    override fun hashCode(): Int {
-        return (startingMark.z + adjacentMark.z) * 1_000_000 + // 1 & 1 -> 2_000_000
-                (startingMark.y + adjacentMark.y) * 1_000 + // 1 & 1 -> 2_002_000
-                (startingMark.x + adjacentMark.x) // 1 & 1 -> 2_002_002
-        // this is only beginning implementation - later check upper limits & maybe include lineDirection here
-    }
+        // if we override equals -> we have to override hashCode as well to prevent from breaking their contract
+        override fun hashCode(): Int {
+            return (startingMark.z + adjacentMark.z) * 1_000_000 + // 1 & 1 -> 2_000_000
+                    (startingMark.y + adjacentMark.y) * 1_000 + // 1 & 1 -> 2_002_000
+                    (startingMark.x + adjacentMark.x) // 1 & 1 -> 2_002_002
+            // this is only beginning implementation - later check upper limits & maybe include lineDirection here
+        }
+    */
 }
+
+internal fun Set<Line?>.getMaxLength(): Int =
+    this.maxByOrNull { line: Line? -> line?.marks?.size ?: 0 }?.marks?.size ?: 0

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/Line.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/Line.kt
@@ -1,22 +1,46 @@
 package geometry
 
-// todo: analyze this experimental idea
-//internal class Line {
-//
-//    val length: Int = 0
-//
-////    val startingPoint: Coordinates
-////    val endingPoint: Coordinates
-//
-//    fun plus(anotherLine: Line) {
-//
-//    }
-//
-//    fun increase(newDotDirection: LineDirection) {
-//        // shift starting point coordinate to opposite??? direction
-//    }
-//
-//    fun getTheLineDirection() {
-//
-//    }
-//}
+import constants.MAX_WINNING_LINE_LENGTH
+import geometry.abstractions.Coordinates
+
+/**
+ * a line is more than one adjacent dot/mark in one constant direction.
+ * for now a line can only grow during detection work, it cannot become smaller.
+ * any line consists of minimum two dots/marks.
+ * two different lines with different order of dots/marks inside are equal.
+ * processing/detecting of the line direction is not a job of the line.
+ * all existing lines are meant to be proven/correct/checked to be straight & aligned in a direction.
+ */
+internal data class Line(val startingMark: Coordinates, val adjacentMark: Coordinates) {
+
+    // decided to initially allocate maximum of memory to avoid possible re-allocations
+    val marks: ArrayDeque<Coordinates> = ArrayDeque(initialCapacity = MAX_WINNING_LINE_LENGTH)
+
+    init {
+        marks.addFirst(startingMark)
+        marks.addLast(adjacentMark)
+    }
+
+    internal fun addToHead(newMark: Coordinates) {
+        marks.addFirst(newMark)
+    }
+
+    internal fun addToTail(newMark: Coordinates) {
+        marks.addLast(newMark)
+    }
+
+    // it is decided to treat two lines with similar marks but opposite direction as one (the same) line
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return if (other == null || other !is Line) false
+        else this.startingMark == other.adjacentMark && this.adjacentMark == other.startingMark
+    }
+
+    // if we override equals -> we have to override hashCode as well to prevent from breaking their contract
+    override fun hashCode(): Int {
+        return (startingMark.z + adjacentMark.z) * 1_000_000 + // 1 & 1 -> 2_000_000
+                (startingMark.y + adjacentMark.y) * 1_000 + // 1 & 1 -> 2_002_000
+                (startingMark.x + adjacentMark.x) // 1 & 1 -> 2_002_002
+        // this is only beginning implementation - later check upper limits & maybe include lineDirection here
+    }
+}

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/Line.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/Line.kt
@@ -18,7 +18,7 @@ internal class Line(startingMark: Coordinates, adjacentMark: Coordinates) {
      * also I decided to avoid using LineDirection concept here - for simplicity.
      * all control of line correctness is done at the level of line detection inside existing logic chains.
      */
-    val marks: MutableSet<Coordinates> = mutableSetOf()
+    internal val marks: MutableSet<Coordinates> = mutableSetOf()
 
     init {
         marks.add(startingMark)
@@ -29,22 +29,21 @@ internal class Line(startingMark: Coordinates, adjacentMark: Coordinates) {
         marks.add(newMark)
     }
 
-    /*
-        // it is decided to treat two lines with similar marks but opposite direction as one (the same) line
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            return if (other == null || other !is Line) false
-            else this.startingMark == other.adjacentMark && this.adjacentMark == other.startingMark
-        }
+    // it is decided to treat two lines with similar marks but opposite direction as one (the same) line
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return if (other == null || other !is Line) false
+        else marks == other.marks // as we use unordered set - it will be the same for opposite line as well
+    }
 
-        // if we override equals -> we have to override hashCode as well to prevent from breaking their contract
-        override fun hashCode(): Int {
-            return (startingMark.z + adjacentMark.z) * 1_000_000 + // 1 & 1 -> 2_000_000
-                    (startingMark.y + adjacentMark.y) * 1_000 + // 1 & 1 -> 2_002_000
-                    (startingMark.x + adjacentMark.x) // 1 & 1 -> 2_002_002
-            // this is only beginning implementation - later check upper limits & maybe include lineDirection here
-        }
-    */
+    // if we override equals -> we have to override hashCode as well to prevent from breaking their contract
+    override fun hashCode(): Int {
+        return marks.hashCode() // as a line is a set of marks - let recognize it by the set of marks
+    }
+
+    override fun toString(): String {
+        return marks.toString()
+    }
 }
 
 internal fun Set<Line?>.getMaxLength(): Int =

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/abstractions/OneMoveProcessing.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/abstractions/OneMoveProcessing.kt
@@ -1,11 +1,14 @@
 package geometry.abstractions
 
+import attt.Player
+import geometry.Line
+
 /**
  * abstraction for any action to be done right after every move is made - it analyses the new state of the game field
  */
 internal interface OneMoveProcessing {
 
-    fun getMaxLengthAchievedForThisMove(where: Coordinates): Int?
+    fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int?
 
     fun getCoordinatesFor(x: Int, y: Int, z: Int = 0): Coordinates
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/abstractions/OneMoveProcessing.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/abstractions/OneMoveProcessing.kt
@@ -8,7 +8,11 @@ import geometry.Line
  */
 internal interface OneMoveProcessing {
 
-    fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int?
+    fun getMaxLengthAchievedForThisMove(
+        where: Coordinates,
+        saveNewLine: (Player, Line) -> Unit,
+        addNewMark: (Player, Coordinates) -> Unit
+    ): Int?
 
     fun getCoordinatesFor(x: Int, y: Int, z: Int = 0): Coordinates
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept2D/NearestAreaScanWith2D.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept2D/NearestAreaScanWith2D.kt
@@ -10,7 +10,9 @@ import utilities.Log
 
 internal class NearestAreaScanWith2D(private val gameField: GameField) : OneMoveProcessing {
 
-    override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
+    override fun getMaxLengthAchievedForThisMove(
+        where: Coordinates, saveNewLine: (Player, Line) -> Unit, addNewMark: (Player, Coordinates) -> Unit
+    ): Int? {
         if (where !is Coordinates2D) return null
         return detectAllExistingLineDirectionsFromThePlacedMark(where, saveNewLine)
             .maxOfOrNull { twoAxisDirection ->

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept2D/NearestAreaScanWith2D.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept2D/NearestAreaScanWith2D.kt
@@ -12,7 +12,7 @@ internal class NearestAreaScanWith2D(private val gameField: GameField) : OneMove
 
     override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
         if (where !is Coordinates2D) return null
-        return detectAllExistingLineDirectionsFromThePlacedMark(where)
+        return detectAllExistingLineDirectionsFromThePlacedMark(where, saveNewLine)
             .maxOfOrNull { twoAxisDirection ->
                 measureFullLengthForExistingLineFrom(where, twoAxisDirection)
             }
@@ -20,7 +20,9 @@ internal class NearestAreaScanWith2D(private val gameField: GameField) : OneMove
 
     override fun getCoordinatesFor(x: Int, y: Int, z: Int): Coordinates = Coordinates2D(x, y)
 
-    private fun detectAllExistingLineDirectionsFromThePlacedMark(fromWhere: Coordinates2D): List<LineDirectionFor2Axes> {
+    private fun detectAllExistingLineDirectionsFromThePlacedMark(
+        fromWhere: Coordinates2D, saveNewLine: (Player, Line) -> Unit
+    ): List<LineDirectionFor2Axes> {
         val checkedMark = gameField.getCurrentMarkAt(fromWhere)
         if (checkedMark == null || checkedMark == PlayerModel.None) {
             return emptyList() // preventing from doing detection calculations for initially wrong Player
@@ -35,6 +37,7 @@ internal class NearestAreaScanWith2D(private val gameField: GameField) : OneMove
             ) {
                 allDirections.add(twoAxisDirection)
                 Log.pl("line exists in direction: $twoAxisDirection")
+                saveNewLine(checkedMark, Line(fromWhere, nextCoordinates))
             }
         }
         return allDirections // is empty if no lines ae found in all possible directions

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept2D/NearestAreaScanWith2D.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept2D/NearestAreaScanWith2D.kt
@@ -1,6 +1,8 @@
 package geometry.concept2D
 
+import attt.Player
 import gameLogic.GameField
+import geometry.Line
 import geometry.abstractions.Coordinates
 import geometry.abstractions.OneMoveProcessing
 import players.PlayerModel
@@ -8,7 +10,7 @@ import utilities.Log
 
 internal class NearestAreaScanWith2D(private val gameField: GameField) : OneMoveProcessing {
 
-    override fun getMaxLengthAchievedForThisMove(where: Coordinates): Int? {
+    override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
         if (where !is Coordinates2D) return null
         return detectAllExistingLineDirectionsFromThePlacedMark(where)
             .maxOfOrNull { twoAxisDirection ->

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
@@ -12,7 +12,7 @@ internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMove
 
     override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
         if (where !is Coordinates3D) return null
-        return detectAllExistingLineDirectionsFromThePlacedMark(where)
+        return detectAllExistingLineDirectionsFromThePlacedMark(where, saveNewLine)
             .maxOfOrNull { threeAxesDirection ->
                 measureFullLengthForExistingLineFrom(where, threeAxesDirection)
             }
@@ -20,7 +20,9 @@ internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMove
 
     override fun getCoordinatesFor(x: Int, y: Int, z: Int): Coordinates = Coordinates3D(x, y, z)
 
-    private fun detectAllExistingLineDirectionsFromThePlacedMark(fromWhere: Coordinates3D): List<LineDirectionFor3Axes> {
+    private fun detectAllExistingLineDirectionsFromThePlacedMark(
+        fromWhere: Coordinates3D, saveNewLine: (Player, Line) -> Unit
+    ): List<LineDirectionFor3Axes> {
         val checkedMark = gameField.getCurrentMarkAt(fromWhere)
         if (checkedMark == null || checkedMark == PlayerModel.None) {
             return emptyList() // preventing from doing detection calculations for initially wrong Player
@@ -35,6 +37,7 @@ internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMove
             ) {
                 allDirections.add(threeAxisDirection)
                 Log.pl("line exists in direction: $threeAxisDirection")
+                saveNewLine(checkedMark, Line(fromWhere, nextCoordinates))
             }
         }
         return allDirections // is empty if no lines ae found in all possible directions

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
@@ -10,7 +10,9 @@ import utilities.Log
 
 internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMoveProcessing {
 
-    override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
+    override fun getMaxLengthAchievedForThisMove(
+        where: Coordinates, saveNewLine: (Player, Line) -> Unit, addNewMark: (Player, Coordinates) -> Unit
+    ): Int? {
         if (where !is Coordinates3D) return null
         return detectAllExistingLineDirectionsFromThePlacedMark(where, saveNewLine)
             .maxOfOrNull { threeAxesDirection ->

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
@@ -1,6 +1,8 @@
 package geometry.concept3D
 
+import attt.Player
 import gameLogic.GameField
+import geometry.Line
 import geometry.abstractions.Coordinates
 import geometry.abstractions.OneMoveProcessing
 import players.PlayerModel
@@ -8,7 +10,7 @@ import utilities.Log
 
 internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMoveProcessing {
 
-    override fun getMaxLengthAchievedForThisMove(where: Coordinates): Int? {
+    override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
         if (where !is Coordinates3D) return null
         return detectAllExistingLineDirectionsFromThePlacedMark(where)
             .maxOfOrNull { threeAxesDirection ->

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/concept3D/NearestAreaScanWith3D.kt
@@ -11,12 +11,14 @@ import utilities.Log
 internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMoveProcessing {
 
     override fun getMaxLengthAchievedForThisMove(
-        where: Coordinates, saveNewLine: (Player, Line) -> Unit, addNewMark: (Player, Coordinates) -> Unit
+        where: Coordinates,
+        saveNewLine: (Player, Line) -> Unit,
+        addNewMark: (Player, Coordinates) -> Unit
     ): Int? {
         if (where !is Coordinates3D) return null
         return detectAllExistingLineDirectionsFromThePlacedMark(where, saveNewLine)
             .maxOfOrNull { threeAxesDirection ->
-                measureFullLengthForExistingLineFrom(where, threeAxesDirection)
+                measureFullLengthForExistingLineFrom(where, threeAxesDirection, addNewMark)
             }
     }
 
@@ -46,7 +48,9 @@ internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMove
     }
 
     private fun measureFullLengthForExistingLineFrom(
-        start: Coordinates3D, lineDirectionFor3Axes: LineDirectionFor3Axes
+        start: Coordinates3D,
+        lineDirectionFor3Axes: LineDirectionFor3Axes,
+        addNewMark: (Player, Coordinates) -> Unit
     ): Int {
         // here we already have a detected line of 2 minimum dots, now let's measure its full potential length.
         // we also have a proven placed dot of the same player in the detected line direction.
@@ -60,15 +64,18 @@ internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMove
         var lineTotalLength = 0
         if (checkedNearCoordinates is Coordinates3D) {
             lineTotalLength =
-                measureLineFrom(checkedNearCoordinates, lineDirectionFor3Axes, 2) +
-                        measureLineFrom(start, lineDirectionFor3Axes.opposite(), 0)
+                measureLineFrom(checkedNearCoordinates, lineDirectionFor3Axes, 2, addNewMark) +
+                        measureLineFrom(start, lineDirectionFor3Axes.opposite(), 0, addNewMark)
             Log.pl("makeNewMove: lineTotalLength = $lineTotalLength")
         } // else checkedNearCoordinates cannot be Border or anything else apart from Coordinates type
         return lineTotalLength
     }
 
     private fun measureLineFrom(
-        givenMark: Coordinates3D, lineDirectionFor3Axes: LineDirectionFor3Axes, startingLength: Int
+        givenMark: Coordinates3D,
+        lineDirectionFor3Axes: LineDirectionFor3Axes,
+        startingLength: Int,
+        addNewMark: (Player, Coordinates) -> Unit
     ): Int {
         Log.pl("measureLineFrom: given startingLength: $startingLength")
         Log.pl("measureLineFrom: given start coordinates: $givenMark")
@@ -81,7 +88,9 @@ internal class NearestAreaScanWith3D(private val gameField: GameField) : OneMove
         )
         Log.pl("measureLineFrom: detected next coordinates: $nextMark")
         return if (nextMark is Coordinates3D && gameField.belongToTheSameRealPlayer(givenMark, nextMark)) {
-            measureLineFrom(nextMark, lineDirectionFor3Axes, startingLength + 1)
+            // here the line gets longer by one new mark, this is a side effect to the measurement
+            gameField.getCurrentMarkAt(givenMark)?.let { addNewMark(it, nextMark) }
+            measureLineFrom(nextMark, lineDirectionFor3Axes, startingLength + 1, addNewMark)
         } else {
             Log.pl("measureLineFrom: ELSE -> exit: $startingLength")
             startingLength

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/conceptXY/NearestAreaScanWithXY.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/conceptXY/NearestAreaScanWithXY.kt
@@ -1,6 +1,8 @@
 package geometry.conceptXY
 
+import attt.Player
 import gameLogic.GameField
+import geometry.Line
 import geometry.abstractions.Coordinates
 import geometry.abstractions.OneMoveProcessing
 import players.PlayerModel
@@ -8,7 +10,7 @@ import utilities.Log
 
 internal class NearestAreaScanWithXY(private val gameField: GameField) : OneMoveProcessing {
 
-    override fun getMaxLengthAchievedForThisMove(where: Coordinates): Int? {
+    override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
         if (where !is CoordinatesXY) return null
         return detectAllExistingLineDirectionsFromThePlacedMark(where)
             .maxOfOrNull { lineDirection ->

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/conceptXY/NearestAreaScanWithXY.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/conceptXY/NearestAreaScanWithXY.kt
@@ -10,7 +10,11 @@ import utilities.Log
 
 internal class NearestAreaScanWithXY(private val gameField: GameField) : OneMoveProcessing {
 
-    override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
+    override fun getMaxLengthAchievedForThisMove(
+        where: Coordinates,
+        saveNewLine: (Player, Line) -> Unit,
+        addNewMark: (Player, Coordinates) -> Unit
+    ): Int? {
         if (where !is CoordinatesXY) return null
         return detectAllExistingLineDirectionsFromThePlacedMark(where, saveNewLine)
             .maxOfOrNull { lineDirection ->

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/conceptXY/NearestAreaScanWithXY.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/geometry/conceptXY/NearestAreaScanWithXY.kt
@@ -12,7 +12,7 @@ internal class NearestAreaScanWithXY(private val gameField: GameField) : OneMove
 
     override fun getMaxLengthAchievedForThisMove(where: Coordinates, saveNewLine: (Player, Line) -> Unit): Int? {
         if (where !is CoordinatesXY) return null
-        return detectAllExistingLineDirectionsFromThePlacedMark(where)
+        return detectAllExistingLineDirectionsFromThePlacedMark(where, saveNewLine)
             .maxOfOrNull { lineDirection ->
                 measureFullLengthForExistingLineFrom(where, lineDirection)
             }
@@ -20,7 +20,9 @@ internal class NearestAreaScanWithXY(private val gameField: GameField) : OneMove
 
     override fun getCoordinatesFor(x: Int, y: Int, z: Int): Coordinates = CoordinatesXY(x, y)
 
-    private fun detectAllExistingLineDirectionsFromThePlacedMark(fromWhere: CoordinatesXY): List<LineDirectionForXY> {
+    private fun detectAllExistingLineDirectionsFromThePlacedMark(
+        fromWhere: CoordinatesXY, saveNewLine: (Player, Line) -> Unit
+    ): List<LineDirectionForXY> {
         val checkedMark = gameField.getCurrentMarkAt(fromWhere)
         if (checkedMark == null || checkedMark == PlayerModel.None) {
             return emptyList() // preventing from doing detection calculations for initially wrong Player
@@ -33,6 +35,7 @@ internal class NearestAreaScanWithXY(private val gameField: GameField) : OneMove
             ) {
                 allDirections.add(lineDirection)
                 Log.pl("line exists in direction: $lineDirection")
+                saveNewLine(checkedMark, Line(fromWhere, nextCoordinates))
             }
         }
         return allDirections // is empty if no lines ae found in all possible directions

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -34,6 +34,7 @@ class PublicApiTesting {
         assertTrue(game.isGameWon(), "Game should have been won")
         assertEquals(playerX, game.getWinner())
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 
     @Test
@@ -54,6 +55,7 @@ class PublicApiTesting {
         assertTrue(game.isGameWon(), "Game should have been won")
         assertEquals(playerX, game.getWinner())
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 
     @Test
@@ -74,6 +76,7 @@ class PublicApiTesting {
         assertTrue(game.isGameWon(), "Game should have been won")
         assertEquals(playerX, game.getWinner())
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 
     @Test
@@ -86,6 +89,7 @@ class PublicApiTesting {
         assertEquals(playerX, game.getLeader())
         assertEquals(2, game.getLeader().maxLineLength)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForLeadingPlayer()
     }
 
     @Test
@@ -98,6 +102,7 @@ class PublicApiTesting {
         assertEquals(playerX, game.getLeader())
         assertEquals(2, game.getLeader().maxLineLength)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForLeadingPlayer()
     }
 
     @Test
@@ -118,6 +123,7 @@ class PublicApiTesting {
         assertEquals(playerO.id, game.getLeader().id)
         assertEquals(3, game.getLeader().maxLineLength)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForLeadingPlayer()
     }
 
     @Test
@@ -138,6 +144,7 @@ class PublicApiTesting {
         assertEquals(playerO.id, game.getLeader().id)
         assertEquals(3, game.getLeader().maxLineLength)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForLeadingPlayer()
     }
 
     @Test
@@ -158,6 +165,7 @@ class PublicApiTesting {
         assertEquals(PlayerProvider.playersList[0], game.getLeader())
         assertEquals(3, game.getLeader().maxLineLength)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForLeadingPlayer()
     }
 
     @Test
@@ -178,6 +186,7 @@ class PublicApiTesting {
         assertEquals(PlayerProvider.playersList[0], game.getLeader())
         assertEquals(3, game.getLeader().maxLineLength)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForLeadingPlayer()
     }
 
     // kind of a load testing on a field that is big and yet still able to fit into console output
@@ -203,6 +212,7 @@ class PublicApiTesting {
             "player ${game.getLeader()} is leading with maxLineLength: ${game.getLeader().maxLineLength}"
         )
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForLeadingPlayer()
     }
 
     // kind of a load testing on a field that is big and yet still able to fit into console output
@@ -230,5 +240,6 @@ class PublicApiTesting {
             }"
         )
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/VictoryConditionTests.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/VictoryConditionTests.kt
@@ -28,6 +28,7 @@ class VictoryConditionTests {
         assertEquals(MIN_WINNING_LINE_LENGTH, game.getWinner().maxLineLength)
         assertEquals(PlayerModel.None, PlayerProvider.activePlayer)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 
     @Test
@@ -46,6 +47,7 @@ class VictoryConditionTests {
         assertEquals(5, game.getWinner().maxLineLength)
         assertEquals(PlayerModel.None, PlayerProvider.activePlayer)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 
     // this test was provided by Matt Tucker - https://github.com/tuck182 - many thanks for finding a serious bug!
@@ -78,6 +80,7 @@ class VictoryConditionTests {
         assertEquals(MIN_WINNING_LINE_LENGTH, game.getWinner().maxLineLength)
         assertEquals(PlayerModel.None, PlayerProvider.activePlayer)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 
     @Test
@@ -100,11 +103,12 @@ class VictoryConditionTests {
         assertEquals(MIN_WINNING_LINE_LENGTH, game.getWinner().maxLineLength)
         assertEquals(PlayerModel.None, PlayerProvider.activePlayer)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 
     @Test
     fun having3x3Field_realSimulation2PlayersShortenedMovesMade_victoryConditionIsCorrect() {
-        val game = Game.create()
+        val game = Game.create() as GameSession
         val playerO = PlayerProvider.playersList[1]
         game.makeMove(0, 0) // X
         game.makeMove(1, 0) // O
@@ -117,5 +121,6 @@ class VictoryConditionTests {
         assertEquals(MIN_WINNING_LINE_LENGTH, game.getWinner().maxLineLength)
         assertEquals(PlayerModel.None, PlayerProvider.activePlayer)
         game.printCurrentFieldIn2d()
+        game.printExistingLinesForTheWinner()
     }
 }


### PR DESCRIPTION
this is a huge & crucial update!

@tuck182 you can see the "Line" implementation in its simplest and most effective form here. please comment, I'd appreciate this.

@turkovsky please review the functional implementation. I hope you'll like it :)
it's mostly here:
`            chosenAlgorithm.getMaxLengthAchievedForThisMove(
                where,
                saveNewLine = { player, line -> gameProgress.saveNewLine(player, line) },
                addNewMark = { player, coordinates -> gameProgress.addToRecentLine(player, coordinates) }
            )?.let {
`